### PR TITLE
removing itk-io until issues are resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 A bundle of napari plugins useful for 3D+t image processing and analysis for studying developmental biology.
 
 * File input/output plugins
-  * [napari-itk-io](https://www.napari-hub.org/plugins/napari-itk-io) 
   * [ome-zarr](https://www.napari-hub.org/plugins/napari-ome-zarr)
 * Image exploration and visualization tools
   * [animation](https://www.napari-hub.org/plugins/napari-animation)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ napari-plot-profile
 napari-accelerated-pixel-and-object-classification
 napari-brightness-contrast
 napari-ome-zarr
-napari-itk-io
 napari-plugin-search
 napari-segment-blobs-and-things-with-membranes
 napari-simpleitk-image-processing

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     napari-accelerated-pixel-and-object-classification
     napari-brightness-contrast
     napari-ome-zarr
-    napari-itk-io
     napari-plugin-search
     napari-segment-blobs-and-things-with-membranes
     napari-simpleitk-image-processing


### PR DESCRIPTION
I'm removing napari-itk-io because we had some issues in courses and hands-on sessions with collaborators

See also:
* https://github.com/InsightSoftwareConsortium/napari-itk-io/issues/4