### PR TITLE
Update for ocl-wrapper changes in conda package

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,6 @@ Afterwards, activate the environment like this:
     
     conda activate devbio-napari-env
 
-Mac-users please also install this:
-
-    conda install -c conda-forge ocl_icd_wrapper_apple
-    
-Linux users please also install this:
-    
-    conda install -c conda-forge ocl-icd-system
-
 Afterwards, run this command from the command line
 
 ```


### PR DESCRIPTION
The conda package on conda-forge already includes the ocl wrappers as needed for linux and macOS:
https://github.com/conda-forge/devbio-napari-feedstock/pull/17
So specifically installing the wrappers isn't needed anymore.

And if pip installing, then the wrapper isn't needed because `khronos-opencl-icd-loader` won't be installed.

So this section isn't needed anymore.