### PR TITLE
added stl-exporter to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ A bundle of napari plugins useful for 3D+t image processing and analysis for stu
   * Quantification
 * [skimage-regionprops](https://www.napari-hub.org/plugins/napari-skimage-regionprops)
   * Quantification
+* [stl-exporter](https://www.napari-hub.org/plugins/napari-stl-exporter)
+  * File input/output
 * [tabu](https://www.napari-hub.org/plugins/napari-tabu)
   * Interaction
 * [the-segmentation-game](https://www.napari-hub.org/plugins/the-segmentation-game)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ napari-simpleitk-image-processing
 napari-folder-browser
 napari-crop
 napari-clusters-plotter>=0.7.1
+napari-stl-exporter
 napari-tabu
 napari-workflow-optimizer
 napari-workflow-inspector

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     napari-plugin-search
     napari-segment-blobs-and-things-with-membranes
     napari-simpleitk-image-processing
+    napari-stl-exporter
     napari-folder-browser
     napari-crop
     napari-clusters-plotter>=0.7.1


### PR DESCRIPTION
@haesleinhuepf With the napari-stl-exporter being on [conda-forge](https://anaconda.org/conda-forge/napari-stl-exporter), this should be good to go :)

Fixes #25 