### PR TITLE
Update README.md to include pyqt in conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can install `devbio-napari` via conda/mamba. If you have never used conda be
 Start by creating an environment using mamba.
 
 ```
-mamba create --name devbio-napari-env python=3.9 devbio-napari -c conda-forge -c pytorch
+mamba create --name devbio-napari-env python=3.9 devbio-napari pyqt -c conda-forge -c pytorch
 ```
 
 Afterwards, activate the environment like this:


### PR DESCRIPTION
the napari package on conda-forge no longer includes a QT backend, see:
https://github.com/napari/docs/pull/202
https://github.com/conda-forge/napari-feedstock/pull/48

So the stand-alone conda instructions need to include one, e.g. `pyqt`.
Here's the napari.org instructions:
<img width="742" alt="image" src="https://github.com/haesleinhuepf/devbio-napari/assets/76622105/0e31fda7-cedc-4f77-bc35-70652845aafc">
screenshot from: https://napari.org/stable/tutorials/fundamentals/installation.html#install-as-python-package-recommended